### PR TITLE
BOOKKEEPER-1006 Remove Bookie global ZK instance

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -28,17 +28,19 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.bookkeeper.bookie.EntryLogger.EntryLogScanner;
 import org.apache.bookkeeper.bookie.GarbageCollector.GarbageCleaner;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.util.MathUtils;
+import org.apache.bookkeeper.util.SafeRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,12 +48,15 @@ import org.slf4j.LoggerFactory;
  * This is the garbage collector thread that runs in the background to
  * remove any entry log files that no longer contains any active ledger.
  */
-public class GarbageCollectorThread extends BookieThread {
+public class GarbageCollectorThread extends SafeRunnable {
     private static final Logger LOG = LoggerFactory.getLogger(GarbageCollectorThread.class);
     private static final int SECOND = 1000;
 
     // Maps entry log files to the set of ledgers that comprise the file and the size usage per ledger
     private Map<Long, EntryLogMetadata> entryLogMetaMap = new ConcurrentHashMap<Long, EntryLogMetadata>();
+
+    ScheduledExecutorService gcExecutor;
+    Future<?> scheduledFuture = null;
 
     // This is how often we want to run the Garbage Collector Thread (in milliseconds).
     final long gcWaitTime;
@@ -188,7 +193,9 @@ public class GarbageCollectorThread extends BookieThread {
                                   LedgerManager ledgerManager,
                                   final CompactableLedgerStorage ledgerStorage)
         throws IOException {
-        super("GarbageCollectorThread");
+        gcExecutor = Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder().setNameFormat("GarbageCollectorThread-%d").build()
+        );
 
         this.entryLogger = ledgerStorage.getEntryLogger();
         this.ledgerStorage = ledgerStorage;
@@ -266,10 +273,10 @@ public class GarbageCollectorThread extends BookieThread {
         lastMinorCompactionTime = lastMajorCompactionTime = MathUtils.now();
     }
 
-    public synchronized void enableForceGC() {
+    public void enableForceGC() {
         if (forceGarbageCollection.compareAndSet(false, true)) {
             LOG.info("Forced garbage collection triggered by thread: {}", Thread.currentThread().getName());
-            notify();
+            triggerGC();
         }
     }
 
@@ -278,6 +285,13 @@ public class GarbageCollectorThread extends BookieThread {
             LOG.info("{} disabled force garbage collection since bookie has enough space now.", Thread
                     .currentThread().getName());
         }
+    }
+
+    /**
+     * Manually trigger GC (for testing)
+     */
+    Future<?> triggerGC() {
+        return gcExecutor.submit(this);
     }
 
     public void suspendMajorGC() {
@@ -304,64 +318,60 @@ public class GarbageCollectorThread extends BookieThread {
         }
     }
 
-    @Override
-    public void run() {
-        while (running) {
-            synchronized (this) {
-                try {
-                    wait(gcWaitTime);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    continue;
-                }
-            }
-
-            boolean force = forceGarbageCollection.get();
-            if (force) {
-                LOG.info("Garbage collector thread forced to perform GC before expiry of wait time.");
-            }
-
-            // Extract all of the ledger ID's that comprise all of the entry logs
-            // (except for the current new one which is still being written to).
-            entryLogMetaMap = extractMetaFromEntryLogs(entryLogMetaMap);
-
-            // gc inactive/deleted ledgers
-            doGcLedgers();
-
-            // gc entry logs
-            doGcEntryLogs();
-
-            boolean suspendMajor = suspendMajorCompaction.get();
-            boolean suspendMinor = suspendMinorCompaction.get();
-            if (suspendMajor) {
-                LOG.info("Disk almost full, suspend major compaction to slow down filling disk.");
-            }
-            if (suspendMinor) {
-                LOG.info("Disk full, suspend minor compaction to slow down filling disk.");
-            }
-
-            long curTime = MathUtils.now();
-            if (enableMajorCompaction && (!suspendMajor) &&
-                (force || curTime - lastMajorCompactionTime > majorCompactionInterval)) {
-                // enter major compaction
-                LOG.info("Enter major compaction, suspendMajor {}", suspendMajor);
-                doCompactEntryLogs(majorCompactionThreshold);
-                lastMajorCompactionTime = MathUtils.now();
-                // also move minor compaction time
-                lastMinorCompactionTime = lastMajorCompactionTime;
-                continue;
-            }
-
-            if (enableMinorCompaction && (!suspendMinor) &&
-                (force || curTime - lastMinorCompactionTime > minorCompactionInterval)) {
-                // enter minor compaction
-                LOG.info("Enter minor compaction, suspendMinor {}", suspendMinor);
-                doCompactEntryLogs(minorCompactionThreshold);
-                lastMinorCompactionTime = MathUtils.now();
-            }
-            forceGarbageCollection.set(false);
+    public void start() {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(false);
         }
-        LOG.info("GarbageCollectorThread exited loop!");
+        scheduledFuture = gcExecutor.scheduleAtFixedRate(this, gcWaitTime, gcWaitTime, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void safeRun() {
+        boolean force = forceGarbageCollection.get();
+        if (force) {
+            LOG.info("Garbage collector thread forced to perform GC before expiry of wait time.");
+        }
+
+        // Extract all of the ledger ID's that comprise all of the entry logs
+        // (except for the current new one which is still being written to).
+        entryLogMetaMap = extractMetaFromEntryLogs(entryLogMetaMap);
+
+        // gc inactive/deleted ledgers
+        doGcLedgers();
+
+        // gc entry logs
+        doGcEntryLogs();
+
+        boolean suspendMajor = suspendMajorCompaction.get();
+        boolean suspendMinor = suspendMinorCompaction.get();
+        if (suspendMajor) {
+            LOG.info("Disk almost full, suspend major compaction to slow down filling disk.");
+        }
+        if (suspendMinor) {
+            LOG.info("Disk full, suspend minor compaction to slow down filling disk.");
+        }
+
+        long curTime = MathUtils.now();
+        if (enableMajorCompaction && (!suspendMajor) &&
+            (force || curTime - lastMajorCompactionTime > majorCompactionInterval)) {
+            // enter major compaction
+            LOG.info("Enter major compaction, suspendMajor {}", suspendMajor);
+            doCompactEntryLogs(majorCompactionThreshold);
+            lastMajorCompactionTime = MathUtils.now();
+            // also move minor compaction time
+            lastMinorCompactionTime = lastMajorCompactionTime;
+            forceGarbageCollection.set(false);
+            return;
+        }
+
+        if (enableMinorCompaction && (!suspendMinor) &&
+            (force || curTime - lastMinorCompactionTime > minorCompactionInterval)) {
+            // enter minor compaction
+            LOG.info("Enter minor compaction, suspendMinor {}", suspendMinor);
+            doCompactEntryLogs(minorCompactionThreshold);
+            lastMinorCompactionTime = MathUtils.now();
+        }
+        forceGarbageCollection.set(false);
     }
 
     /**
@@ -468,12 +478,16 @@ public class GarbageCollectorThread extends BookieThread {
     public void shutdown() throws InterruptedException {
         this.running = false;
         LOG.info("Shutting down GarbageCollectorThread");
-        if (compacting.compareAndSet(false, true)) {
-            // if setting compacting flag succeed, means gcThread is not compacting now
-            // it is safe to interrupt itself now
-            this.interrupt();
+
+        while (!compacting.compareAndSet(false, true)) {
+            // Wait till the thread stops compacting
+            wait(100);
         }
-        this.join();
+        gcExecutor.shutdown();
+        if (gcExecutor.awaitTermination(60, TimeUnit.SECONDS)) {
+            LOG.warn("GC executor did not shut down in 60 seconds. Killing");
+            gcExecutor.shutdownNow();
+        }
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/GarbageCollectorThread.java
@@ -39,8 +39,13 @@ import org.apache.bookkeeper.bookie.EntryLogger.EntryLogScanner;
 import org.apache.bookkeeper.bookie.GarbageCollector.GarbageCleaner;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.meta.LedgerManager;
+import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.util.MathUtils;
 import org.apache.bookkeeper.util.SafeRunnable;
+import org.apache.bookkeeper.util.ZkUtils;
+import org.apache.bookkeeper.zookeeper.ZooKeeperWatcherBase;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,6 +90,9 @@ public class GarbageCollectorThread extends SafeRunnable {
     final EntryLogger entryLogger;
 
     final CompactableLedgerStorage ledgerStorage;
+    final LedgerManagerProvider ledgerManagerProvider;
+    final ServerConfiguration conf;
+
 
     // flag to ensure gc thread will not be interrupted during compaction
     // to reduce the risk getting entry log corrupted
@@ -102,7 +110,6 @@ public class GarbageCollectorThread extends SafeRunnable {
     // Boolean to disable minor compaction, when disk is full
     final AtomicBoolean suspendMinorCompaction = new AtomicBoolean(false);
 
-    final GarbageCollector garbageCollector;
     final GarbageCleaner garbageCleaner;
 
     private static class Throttler {
@@ -190,7 +197,7 @@ public class GarbageCollectorThread extends SafeRunnable {
      * @throws IOException
      */
     public GarbageCollectorThread(ServerConfiguration conf,
-                                  LedgerManager ledgerManager,
+                                  LedgerManagerProvider ledgerManagerProvider,
                                   final CompactableLedgerStorage ledgerStorage)
         throws IOException {
         gcExecutor = Executors.newSingleThreadScheduledExecutor(
@@ -199,6 +206,8 @@ public class GarbageCollectorThread extends SafeRunnable {
 
         this.entryLogger = ledgerStorage.getEntryLogger();
         this.ledgerStorage = ledgerStorage;
+        this.ledgerManagerProvider = ledgerManagerProvider;
+        this.conf = conf;
 
         this.gcWaitTime = conf.getGcWaitTime();
         this.isThrottleByBytes = conf.getIsThrottleByBytes();
@@ -221,8 +230,6 @@ public class GarbageCollectorThread extends SafeRunnable {
                 }
             }
         };
-
-        this.garbageCollector = new ScanAndCompareGarbageCollector(ledgerManager, ledgerStorage, conf);
 
         // compaction parameters
         minorCompactionThreshold = conf.getMinorCompactionThreshold();
@@ -336,49 +343,51 @@ public class GarbageCollectorThread extends SafeRunnable {
         // (except for the current new one which is still being written to).
         entryLogMetaMap = extractMetaFromEntryLogs(entryLogMetaMap);
 
-        // gc inactive/deleted ledgers
-        doGcLedgers();
 
-        // gc entry logs
-        doGcEntryLogs();
+        try {
+            LedgerManager ledgerManager = ledgerManagerProvider.getLedgerManager();
 
-        boolean suspendMajor = suspendMajorCompaction.get();
-        boolean suspendMinor = suspendMinorCompaction.get();
-        if (suspendMajor) {
-            LOG.info("Disk almost full, suspend major compaction to slow down filling disk.");
-        }
-        if (suspendMinor) {
-            LOG.info("Disk full, suspend minor compaction to slow down filling disk.");
-        }
+            // gc inactive/deleted ledgers
+            GarbageCollector collector = new ScanAndCompareGarbageCollector(
+                    ledgerManager, ledgerStorage, conf);
 
-        long curTime = MathUtils.now();
-        if (enableMajorCompaction && (!suspendMajor) &&
-            (force || curTime - lastMajorCompactionTime > majorCompactionInterval)) {
-            // enter major compaction
-            LOG.info("Enter major compaction, suspendMajor {}", suspendMajor);
-            doCompactEntryLogs(majorCompactionThreshold);
-            lastMajorCompactionTime = MathUtils.now();
-            // also move minor compaction time
-            lastMinorCompactionTime = lastMajorCompactionTime;
-            forceGarbageCollection.set(false);
-            return;
-        }
+            collector.gc(garbageCleaner);
 
-        if (enableMinorCompaction && (!suspendMinor) &&
-            (force || curTime - lastMinorCompactionTime > minorCompactionInterval)) {
-            // enter minor compaction
-            LOG.info("Enter minor compaction, suspendMinor {}", suspendMinor);
-            doCompactEntryLogs(minorCompactionThreshold);
-            lastMinorCompactionTime = MathUtils.now();
+            // gc entry logs
+            doGcEntryLogs();
+
+            boolean suspendMajor = suspendMajorCompaction.get();
+            boolean suspendMinor = suspendMinorCompaction.get();
+            if (suspendMajor) {
+                LOG.info("Disk almost full, suspend major compaction to slow down filling disk.");
+            }
+            if (suspendMinor) {
+                LOG.info("Disk full, suspend minor compaction to slow down filling disk.");
+            }
+
+            long curTime = MathUtils.now();
+            if (enableMajorCompaction && (!suspendMajor) &&
+                    (force || curTime - lastMajorCompactionTime > majorCompactionInterval)) {
+                // enter major compaction
+                LOG.info("Enter major compaction, suspendMajor {}", suspendMajor);
+                doCompactEntryLogs(majorCompactionThreshold);
+                lastMajorCompactionTime = MathUtils.now();
+                // also move minor compaction time
+                lastMinorCompactionTime = lastMajorCompactionTime;
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            LOG.info("Garbage collection interrupted", ie);
+        } catch (Exception e) {
+            LOG.warn("Exception in gc", e);
+        } finally {
+            try {
+                ledgerManagerProvider.releaseResources();
+            } catch (Exception e) {
+                LOG.warn("Exception while cleaning up ledger manager resources", e);
+            }
         }
         forceGarbageCollection.set(false);
-    }
-
-    /**
-     * Do garbage collection ledger index files
-     */
-    private void doGcLedgers() {
-        garbageCollector.gc(garbageCleaner);
     }
 
     /**
@@ -579,5 +588,54 @@ public class GarbageCollectorThread extends SafeRunnable {
             }
         }
         return entryLogMetaMap;
+    }
+
+    /**
+     * This interfaces exist so dummy ledger managers can
+     * be injected for testing. We should move to a proper DI implementation at some point.
+     */
+    public interface LedgerManagerProvider {
+        LedgerManager getLedgerManager() throws InterruptedException, KeeperException, IOException;
+        void releaseResources() throws IOException, InterruptedException;
+    }
+
+    public static class LedgerManagerProviderImpl implements LedgerManagerProvider {
+        final ServerConfiguration conf;
+        ZooKeeper zk = null;
+        LedgerManagerFactory lmfactory = null;
+        LedgerManager ledgerManager = null;
+
+        LedgerManagerProviderImpl(ServerConfiguration conf) {
+            this.conf = conf;
+        }
+
+        public LedgerManager getLedgerManager() throws InterruptedException, KeeperException, IOException {
+            zk = ZkUtils.createConnectedZookeeperClient(conf.getZkServers(),
+                    new ZooKeeperWatcherBase(conf.getZkTimeout()));
+            lmfactory = LedgerManagerFactory.newLedgerManagerFactory(conf, zk);
+            LOG.info("instantiate ledger manager {}", lmfactory.getClass().getName());
+            ledgerManager = lmfactory.newLedgerManager();
+            return ledgerManager;
+        }
+
+        public ZooKeeper getZooKeeper() {
+            return zk;
+        }
+
+        public void releaseResources() throws IOException, InterruptedException {
+            if (ledgerManager != null) {
+                ledgerManager.close();
+                ledgerManager = null;
+            }
+            if (lmfactory != null) {
+                lmfactory.uninitialize();
+                lmfactory = null;
+            }
+            if (zk != null) {
+                zk.close();
+                zk = null;
+            }
+        }
+
     }
 }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/InterleavedLedgerStorage.java
@@ -103,7 +103,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
     }
 
     @Override
-    public void initialize(ServerConfiguration conf, LedgerManager ledgerManager,
+    public void initialize(ServerConfiguration conf, GarbageCollectorThread.LedgerManagerProvider ledgerManagerProvider,
                            LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
                            CheckpointSource checkpointSource, StatsLogger statsLogger)
             throws IOException {
@@ -112,7 +112,7 @@ public class InterleavedLedgerStorage implements CompactableLedgerStorage, Entry
         entryLogger = new EntryLogger(conf, ledgerDirsManager, this);
         ledgerCache = new LedgerCacheImpl(conf, activeLedgers,
                 null == indexDirsManager ? ledgerDirsManager : indexDirsManager, statsLogger);
-        gcThread = new GarbageCollectorThread(conf, ledgerManager, this);
+        gcThread = new GarbageCollectorThread(conf, ledgerManagerProvider, this);
         ledgerDirsManager.addLedgerDirsListener(getLedgerDirsListener());
         // Expose Stats
         getOffsetStats = statsLogger.getOpStatsLogger(STORAGE_GET_OFFSET);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/LedgerStorage.java
@@ -41,10 +41,10 @@ public interface LedgerStorage {
      * Initialize the LedgerStorage implementation
      *
      * @param conf
-     * @param ledgerManager
+     * @param ledgerManagerProvider
      * @param ledgerDirsManager
      */
-    public void initialize(ServerConfiguration conf, LedgerManager ledgerManager,
+    public void initialize(ServerConfiguration conf, GarbageCollectorThread.LedgerManagerProvider ledgerManagerProvider,
                            LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
                            CheckpointSource checkpointSource, StatsLogger statsLogger)
             throws IOException;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/SortedLedgerStorage.java
@@ -47,11 +47,12 @@ public class SortedLedgerStorage extends InterleavedLedgerStorage
     }
 
     @Override
-    public void initialize(ServerConfiguration conf, LedgerManager ledgerManager,
+    public void initialize(ServerConfiguration conf, GarbageCollectorThread.LedgerManagerProvider ledgerManagerProvider,
                            LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
                            final CheckpointSource checkpointSource, StatsLogger statsLogger)
             throws IOException {
-        super.initialize(conf, ledgerManager, ledgerDirsManager, indexDirsManager, checkpointSource, statsLogger);
+        super.initialize(conf, ledgerManagerProvider, ledgerDirsManager,
+                         indexDirsManager, checkpointSource, statsLogger);
         this.memTable = new EntryMemTable(conf, checkpointSource, statsLogger);
         this.scheduler = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder()

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ZkUtils.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ZkUtils.java
@@ -231,4 +231,29 @@ public class ZkUtils {
         }, null);
     }
 
+    /**
+     * Get new ZooKeeper client. Waits till the connection is complete. If
+     * connection is not successful within timeout, then throws back exception.
+     *
+     * @param servers
+     *            ZK servers connection string.
+     * @param timeout
+     *            Session timeout.
+     */
+    public static ZooKeeper createConnectedZookeeperClient(String servers,
+                                                           ZooKeeperWatcherBase w) throws IOException, InterruptedException,
+            KeeperException {
+        if (servers == null || servers.isEmpty()) {
+            throw new IllegalArgumentException("servers cannot be empty");
+        }
+        final ZooKeeper newZk = new ZooKeeper(servers, w.getZkSessionTimeOut(),
+                w);
+        w.waitForConnection();
+        // Re-checking zookeeper connection status
+        if (!newZk.getState().isConnected()) {
+            throw KeeperException.create(KeeperException.Code.CONNECTIONLOSS);
+        }
+        return newZk;
+    }
+
 }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieAccessor.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/BookieAccessor.java
@@ -21,6 +21,7 @@
 package org.apache.bookkeeper.bookie;
 
 import java.io.IOException;
+import java.util.concurrent.Future;
 
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -229,9 +229,9 @@ public class CompactionTest extends BookKeeperClusterTestCase {
                 dirManager, dirManager, cp, NullStatsLogger.INSTANCE);
         storage.start();
         long startTime = MathUtils.now();
-        Thread.sleep(2000);
         storage.gcThread.enableForceGC();
-        Thread.sleep(1000);
+        storage.gcThread.triggerGC().get(); //major
+        storage.gcThread.triggerGC().get(); //minor
         // Minor and Major compaction times should be larger than when we started
         // this test.
         assertTrue("Minor or major compaction did not trigger even on forcing.",

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/LedgerCacheTest.java
@@ -28,7 +28,6 @@ import java.nio.ByteBuffer;
 import org.apache.bookkeeper.bookie.Bookie.NoLedgerException;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.conf.TestBKConfiguration;
-import org.apache.bookkeeper.meta.LedgerManager;
 import org.apache.bookkeeper.meta.LedgerManagerFactory;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.util.BookKeeperConstants;
@@ -471,10 +470,12 @@ public class LedgerCacheTest {
         }
 
         @Override
-        public void initialize(ServerConfiguration conf, LedgerManager ledgerManager,
-                LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
-                final CheckpointSource checkpointSource, StatsLogger statsLogger) throws IOException {
-            super.initialize(conf, ledgerManager, ledgerDirsManager, indexDirsManager, checkpointSource, statsLogger);
+        public void initialize(ServerConfiguration conf,
+                               GarbageCollectorThread.LedgerManagerProvider ledgerManagerProvider,
+                               LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
+                               final CheckpointSource checkpointSource, StatsLogger statsLogger) throws IOException {
+            super.initialize(conf, ledgerManagerProvider, ledgerDirsManager,
+                             indexDirsManager, checkpointSource, statsLogger);
             this.memTable = new EntryMemTable(conf, checkpointSource, statsLogger) {
                 @Override
                 boolean isSizeLimitReached() {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSyncThread.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/TestSyncThread.java
@@ -269,9 +269,10 @@ public class TestSyncThread {
 
     private static class DummyLedgerStorage implements LedgerStorage {
         @Override
-        public void initialize(ServerConfiguration conf, LedgerManager ledgerManager,
-                LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
-                CheckpointSource checkpointSource, StatsLogger statsLogger)
+        public void initialize(ServerConfiguration conf,
+                               GarbageCollectorThread.LedgerManagerProvider ledgerManagerProvider,
+                               LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
+                               CheckpointSource checkpointSource, StatsLogger statsLogger)
                 throws IOException {
         }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/meta/LedgerManagerTestCase.java
@@ -28,13 +28,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.NavigableMap;
 
-import org.apache.bookkeeper.bookie.BookieException;
-import org.apache.bookkeeper.bookie.CheckpointSource;
+import org.apache.bookkeeper.bookie.*;
 import org.apache.bookkeeper.bookie.CheckpointSource.Checkpoint;
-import org.apache.bookkeeper.bookie.CompactableLedgerStorage;
-import org.apache.bookkeeper.bookie.EntryLocation;
-import org.apache.bookkeeper.bookie.EntryLogger;
-import org.apache.bookkeeper.bookie.LedgerDirsManager;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.bookkeeper.jmx.BKMBeanInfo;
 import org.apache.bookkeeper.stats.StatsLogger;
@@ -114,9 +109,10 @@ public abstract class LedgerManagerTestCase extends BookKeeperClusterTestCase {
     public class MockLedgerStorage implements CompactableLedgerStorage {
 
         @Override
-        public void initialize(ServerConfiguration conf, LedgerManager ledgerManager,
-                LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
-                CheckpointSource checkpointSource, StatsLogger statsLogger) throws IOException {
+        public void initialize(ServerConfiguration conf,
+                               GarbageCollectorThread.LedgerManagerProvider ledgerManagerProvider,
+                               LedgerDirsManager ledgerDirsManager, LedgerDirsManager indexDirsManager,
+                               CheckpointSource checkpointSource, StatsLogger statsLogger) throws IOException {
         }
 
         @Override


### PR DESCRIPTION
Bookie has had a Zookeeper client for the whole process up to now. This
is only ever used in garbage collection though. This change moves the
creation and usage of the zookeeper client to the garbage collection
thread. It now creates a new zookeeper client for each GC iteration, and
tears it down afterwards. This means that if there is a problem with the
zookeeper connection, it will only exist for one iteration of garbage
collection.